### PR TITLE
💄 Use Monospaced Digits for Counting

### DIFF
--- a/PurposefulSwiftUIAnimations/AnimationPrinciples/StagingAnimation/StepsCountingAnimation.swift
+++ b/PurposefulSwiftUIAnimations/AnimationPrinciples/StagingAnimation/StepsCountingAnimation.swift
@@ -38,7 +38,7 @@ struct AnimatableNumberModifier: AnimatableModifier {
                 Text("\(animatableData)")
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
-                    .font(.largeTitle)
+                    .font(.largeTitle.monospacedDigit())
             )
     }
 }


### PR DESCRIPTION
Applying monospaced digits lets the text be less jumpy during the animation.